### PR TITLE
check for ActiveRecord presence before configuring logging

### DIFF
--- a/lib/sinatra/logger.rb
+++ b/lib/sinatra/logger.rb
@@ -34,8 +34,10 @@ module Sinatra
         set :logging, true
         use ::Rack::CommonLogger, ::SemanticLogger["Access"]
 
-        # ActiveRecord Logger
-        ActiveRecord::Base.logger = ::SemanticLogger["SQL"]
+        if defined?(::ActiveRecord::Base)
+          # ActiveRecord Logger
+          ::ActiveRecord::Base.logger = ::SemanticLogger["SQL"]
+        end
 
         ::Sinatra::Base.before do
           ::SemanticLogger.default_level = config[:level]


### PR DESCRIPTION
i get an `NameError: uninitialized constant Sinatra::Logger::ActiveRecord` when I try and use this with my sinatra app that doesn't use AR, so this checks for the class' existence first.